### PR TITLE
Create config dir if it doesn't exist

### DIFF
--- a/trickuri.go
+++ b/trickuri.go
@@ -284,6 +284,10 @@ func httpHandler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
+	err := os.MkdirAll(*directory, os.ModePerm)
+	if err != nil {
+		log.Fatal(err)
+	}
 	certMap = make(map[string]*tls.Certificate)
 	rootCert, err := loadOrCreateRootCertificate()
 	if err != nil {


### PR DESCRIPTION
This adds code to create the config dir (e.g., `~/.trickuri` by default) if it does not already exist. It will exit with an error if this fails.

This fixes #1 