### PR TITLE
Redirect permissions test to HTTPS

### DIFF
--- a/testcases/permissions_test.html
+++ b/testcases/permissions_test.html
@@ -1,6 +1,10 @@
 <html>
   <head>
     <script>
+      // Redirect to https because permission prompts don't fire on http.
+      if (window.location.protocol != "https:") {
+        window.location.protocol = "https";
+      }
       navigator.mediaDevices.getUserMedia({ audio: true, video: false })
     </script>
     <title>Permissions Test</title>


### PR DESCRIPTION
The permissions test case doesn't do anything if you're on HTTP because only HTTPS pages are allowed to request permissions, so redirect directly to HTTPS if the permissions test case is loaded over HTTP.