### PR TITLE
Tweak trickuri documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ This tool is designed to allow testing of applications' display of URLs.
 
 ## Background
 
-URIs are often the only source of identity information available when making
-security decisions in a web browser or other context, but URI syntax is
-complicated and subject to a wide variety of spoofing attacks. This tool allows
+URLs are often the only source of identity information available when making
+security decisions in a web browser or other context, but URL syntax is
+complicated and subject to a wide variety of spoofing attacks. Trickuri allows
 easy exercise of common sources of spoofing vulnerabilities to ensure
-applications are robust in their display of URIs.
+applications are robust in their display of URLs.
 
 ## Implementation
 
-The tool is configured as a proxy server for the client application under test.
+Trickuri is configured as a proxy server for the client application under test.
 All of the client's HTTP requests are sent to the proxy. The proxy returns HTML
 content such that the behavior of the client application can be tested. For
 instance, for Chrome itself, the tester can examine the content of the omnibox
@@ -23,13 +23,13 @@ to verify that the origin is visible and unambiguously identified to the user.
 ## Testcases
 
 Files in the ```testcases``` folder will be served as if they were served from any
-URL, i.e. with the proxy running, visiting google.com/samplepathtest will serve
+URL, i.e. with the proxy running, visiting example.com/samplepathtest will serve
 testcases/samplepathtest. Additional test cases can be added to the testcases
 folder.
 
 ## Running
 
-To run trickuri, run 'go run trickuri.go' in the source directory.
+To run Trickuri, run 'go run trickuri.go' in the source directory.
 
 ## Proxy configuration
 
@@ -38,19 +38,25 @@ The proxy may be configured in one of two ways:
 1.  As a "static proxy", running on port 1270 (by default) of the machine
     running the proxy.
 2.  As an "autoconfigured proxy" where the client pulls
-    http://<IP/Hostname of computer running trickuri>:1270/proxy.pac as the proxy determination script.
+    http://<IP/hostname of computer running Trickuri>:1270/proxy.pac as the
+    proxy determination script.
 
 The advantage of the latter configuration is that it allows the proxy to specify
 that it should be bypassed for certain URLs, e.g. those used by SafeBrowsing,
-component updates, etc. Such bypass helps limit the impact of the proxy on the
+component updates, etc. Such bypasses help limit the impact of the proxy on the
 system under test.
+
+See https://www.chromium.org/developers/design-documents/network-settings for
+instructions on configuring proxy settings if you are testing Chrome with
+Trickuri.
 
 ## Certificate configuration
 
 In order for the tool to be able to intercept HTTPS requests, its root
-certificate needs to be trusted either by the browser or the OS. The root
-certificate can be downloaded from http://localhost:1270/root.cer once the tool
-is running.
+certificate needs to be trusted by the application being tested. If you are
+testing Chrome, this means that you should import the Trickuri root certificate
+into your OS trust store. The root certificate can be downloaded from
+http://localhost:1270/root.cer once Trickuri is running.
 
 ## Flags
 

--- a/testcases/alert_test.html
+++ b/testcases/alert_test.html
@@ -6,5 +6,7 @@
     <title>Alert Test</title>
   </head>
   <body>
+    <p>This page tests how a web browser displays a URL in a Javascript
+      alert dialog.</p>
   </body>
 </html>

--- a/testcases/permissions_test.html
+++ b/testcases/permissions_test.html
@@ -6,5 +6,7 @@
     <title>Permissions Test</title>
   </head>
   <body>
+    <p>This page tests how a web browser displays a URL in a permission
+      prompt.</p>
   </body>
 </html>

--- a/trickuri.go
+++ b/trickuri.go
@@ -145,7 +145,7 @@ func writeCertificate(certificate []byte, key *rsa.PrivateKey, filename string) 
 func loadOrCreateRootCertificate() (tls.Certificate, error) {
 	rootKeys, err := tls.LoadX509KeyPair(*directory+"/root.cer", *directory+"/root.pem")
 	if err != nil {
-		log.Println("root.cer failed to load. Recreating root certificate.")
+		fmt.Println("root.cer failed to load. Recreating root certificate.")
 		rootCert, rootKey, err := createRootCertificate()
 		if err != nil {
 			return tls.Certificate{}, err
@@ -307,9 +307,14 @@ func main() {
 	}
 	caKey = rootCert.PrivateKey
 
-	log.Printf("Download the root certificate at http://localhost:%d/root.cer and import it into browser/OS certificate store.", *port)
-	log.Printf("Set your proxy to \"http://localhost:%[1]d/proxy.pac\" or localhost:%[1]d. Using pac file will pass through requests to google.com and microsoft.com for common Chrome/Windows requests.", *port)
-	log.Println("Ready for requests")
+	fmt.Println("\n")
+	fmt.Println("----Welcome to Trickuri!----")
+	fmt.Println("This tool facilitates testing of applications that displays URLs to users.\n")
+	fmt.Println("Trickuri is ready to receive requests.\n")
+
+	fmt.Printf("1.) Download the root certificate at http://localhost:%d/root.cer and import it into your browser/OS certificate store. See README.md for instructions on how to import a root certificate.\n", *port)
+	fmt.Printf("2.) Set the proxy server of the application under test to \"http://localhost:%[1]d/proxy.pac\" or localhost:%[1]d. Using the pac file will pass through requests to google.com and microsoft.com for common Chrome/Windows requests. See https://www.chromium.org/developers/design-documents/network-settings for instructions on configuring Chrome's proxy server, if you are testing Chrome.\n", *port)
+	fmt.Printf("3.) Visit https://example.com (or any other URL) to see a list of test cases.\n\n")
 
 	cfg := &tls.Config{
 		CipherSuites: []uint16{


### PR DESCRIPTION
- Editorial nits on README
- Add a friendly welcome message
- Use fmt.Println instead of log; I find the timestamps make it hard to read