### PR TITLE
Change default storage dir to match $XDG_CONFIG_HOME.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ http://localhost:1270/root.cer once Trickuri is running.
 
 -h Sets the port for the https server, defaults to 8443.
 
--d Sets the directory for certificate storage, defaults to ~/.trickuri
+-d Sets the directory for certificate storage, defaults to ~/.config/trickuri

--- a/trickuri.go
+++ b/trickuri.go
@@ -42,7 +42,7 @@ import (
 var (
 	port      = flag.Int("p", 1270, "port on which to listen")
 	httpsPort = flag.Int("h", 8443, "port on which the HTTPS proxy will listen")
-	directory = flag.String("d", userHomeDir()+"/.trickuri", "default directory on which to save certificates")
+	directory = flag.String("d", userHomeDir()+"/.config/trickuri", "default directory on which to save certificates")
 )
 
 // Globals


### PR DESCRIPTION
`$XDG_CONFIG_HOME` is a de facto standard for where to store data associated with a program: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

Even better would be to use `$XDG_DATA_DIRS` and read from the env var instead of falling back tot he default, but at that point the best approach would be to use a (third-party) library. The default change in this PR just takes the modest step of moving the cert data folder out of the home dir.