### PR TITLE
Add `view-source` URL test to Simple test cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
       <li><a href="http://[::1]">URL with IPv6 literal hostname</a></li>
       <li><a href="data:,Hello">data: URL</a> (copy and paste URL in Chrome, which disallows top-level navigations to data: URLs)</a></li>
       <li><a href="ftp://example.test">ftp:// URL</a></li>
+      <li><a href="view-source:http://example.test">view-source URL</a></li>           
       </ul>
 
       <h3>IDNs and homoglyphs</h3>


### PR DESCRIPTION
This adds a link to a `view-source` URL below the test for `data` and `ftp` URLs.