### PR TITLE
Add external protocol dialog test

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,11 @@
     <li><a href="/web-feature-tests/webauthn_test.html">WebAuthn</a></li>
     </ul>
 
+    <h3>External protocol handlers</h3>
+    <ul>
+    <li><a href="/web-feature-tests/external_protocol_handler_test.html">External protocol handler</a></li>
+    </ul>
+
   </body>
 </html>
 

--- a/web-feature-tests/external_protocol_handler_test.html
+++ b/web-feature-tests/external_protocol_handler_test.html
@@ -4,6 +4,7 @@
   </head>
   <body>
     <p>This page tests how a web browser displays a request handled by an external protocol handler.</p>
-    <p><a href="magnet:?xt=urn:btih:d58beca4e5ed19a81fd168e8f943e102062e8644">Navigate</a></p>
+    <p><a href="magnet:?xt=urn:btih:d58beca4e5ed19a81fd168e8f943e102062e8644">Navigate on Linux</a></p>
+    <p><a href="itmss://itunes.apple.com/cn/app/id718659370">Navigate on Mac</a></p>
   </body>
 </html>

--- a/web-feature-tests/external_protocol_handler_test.html
+++ b/web-feature-tests/external_protocol_handler_test.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>External Protocol Handler Test</title>
+  </head>
+  <body>
+    <p>This page tests how a web browser displays a request handled by an external protocol handler.</p>
+    <p><a href="magnet:?xt=urn:btih:d58beca4e5ed19a81fd168e8f943e102062e8644">Navigate</a></p>
+  </body>
+</html>


### PR DESCRIPTION
This adds Mac and Linux testcases for the external protocol dialog handler. I didn't add a Windows test case because I don't have a Windows machine handy to test on.